### PR TITLE
Checkbox added on login page for create persistent session (1 year in…

### DIFF
--- a/signin.jade
+++ b/signin.jade
@@ -42,6 +42,14 @@ html
                       required
                     )
               .form-group
+                .col-sm-5
+                  .checkbox
+                    input(
+                      name = 'remember-me'
+                      type = 'checkbox'
+                    )
+                    = 'Remember me'
+              .form-group
                 .col-sm-12
                   button.btn.btn-login.btn-block.btn-success
                     i.fa.fa-sign-in


### PR DESCRIPTION
… practice) only for internal provider.

If checkbox is not checked or if an external provider is used (as Github, Twitter...) the session is not-persistent.