### PR TITLE
Refactor `vm.import()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "is-my-json-valid": "^2.12.2",
     "jade": "^1.11.0",
     "js-yaml": "^3.2.7",
-    "json-rpc-peer": "^0.10.0",
+    "json-rpc-peer": "^0.11.0",
     "julien-f-source-map-support": "0.0.0",
     "julien-f-unzip": "^0.2.1",
     "kindof": "^2.0.0",


### PR DESCRIPTION
- Move logic code to `Xapi#importVm()`
- `vm.import()` following request now returns the id of the imported VM