### PR TITLE
The local xen orchestra timestamp is never used for get stats.

### DIFF
--- a/src/xapi.js
+++ b/src/xapi.js
@@ -1,5 +1,6 @@
 import assign from 'lodash.assign'
 import createDebug from 'debug'
+import d3TimeFormat from 'd3-time-format'
 import escapeStringRegexp from 'escape-string-regexp'
 import eventToPromise from 'event-to-promise'
 import filter from 'lodash.filter'
@@ -75,6 +76,10 @@ forEach([
 const getNamespaceForType = (type) => typeToNamespace[type] || type
 
 // ===================================================================
+
+// Format a date (pseudo ISO 8601) from one XenServer get by
+// xapi.call('host.get_servertime', host.ref) for example
+export const dateTimeFormat = d3TimeFormat.utcFormat('%Y%m%dT%H:%M:%SZ')
 
 export const isHostRunning = (host) => {
   const {$metrics: metrics} = host

--- a/src/xo.js
+++ b/src/xo.js
@@ -945,20 +945,12 @@ export default class Xo extends EventEmitter {
 
   getXapiVmStats (vm, granularity) {
     const xapi = this.getXAPI(vm)
-    let host = this.getObject(vm.$container)
-
-    if (host.type === 'pool') {
-      host = this.getObject(host.master, 'host')
-    } else if (host.type !== 'host') {
-      throw new Error(`unexpected type: got ${host.type} instead of host`)
-    }
-
-    return this._xapiStats.getVmPoints(host.address, granularity, xapi.sessionId, vm.id)
+    return this._xapiStats.getVmPoints(xapi, vm.id, granularity)
   }
 
   getXapiHostStats (host, granularity) {
     const xapi = this.getXAPI(host)
-    return this._xapiStats.getHostPoints(host.address, granularity, xapi.sessionId)
+    return this._xapiStats.getHostPoints(xapi, host.id, granularity)
   }
 
   async mergeXenPools (sourceId, targetId, force = false) {


### PR DESCRIPTION
Only the timestamp of one xenServer/rrd is used.