### PR TITLE
Cancelling a VM export (eg: closing web browser) should cancel the ta…

### DIFF
--- a/src/api/vm.coffee
+++ b/src/api/vm.coffee
@@ -698,9 +698,10 @@ handleExport = $coroutine (req, res, {xapi, id, compress, onlyMetadata}) ->
     compress: compress ? true,
     onlyMetadata: onlyMetadata ? false
   })
-
   upstream = stream.response
-
+  res.on('close', () ->
+    stream.abort()
+  )
   # Remove the filename as it is already part of the URL.
   upstream.headers['content-disposition'] = 'attachment'
 

--- a/src/api/vm.coffee
+++ b/src/api/vm.coffee
@@ -700,7 +700,7 @@ handleExport = $coroutine (req, res, {xapi, id, compress, onlyMetadata}) ->
   })
   upstream = stream.response
   res.on('close', () ->
-    stream.abort()
+    stream.cancel()
   )
   # Remove the filename as it is already part of the URL.
   upstream.headers['content-disposition'] = 'attachment'

--- a/src/xapi.js
+++ b/src/xapi.js
@@ -969,6 +969,7 @@ export default class Xapi extends XapiBase {
       })
     }
 
+    let request
     const stream = got.stream({
       hostname: host.address,
       path: onlyMetadata ? '/export_metadata/' : '/export/'
@@ -980,6 +981,11 @@ export default class Xapi extends XapiBase {
         use_compression: compress ? 'true' : 'false'
       }
     })
+    .on('request', req => request = req)
+
+    stream.abort = () => {
+      request.abort()
+    }
 
     const response = await eventToPromise(stream, 'response')
 


### PR DESCRIPTION
…sk properly.

When the connection with the client is lost, the export task is cancelled and the connection is closed.
As the task is over, the snapshot used for the export is deleted.