### PR TITLE
Properly handle multiple XAPI objects with the same XO id.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -289,6 +289,19 @@ export function parseSize (size) {
 
 // -------------------------------------------------------------------
 
+const _has = Object.prototype.hasOwnProperty
+
+// Removes an own property from an object and returns its value.
+export const popProperty = obj => {
+  for (const prop in obj) {
+    if (_has.call(obj, prop)) {
+      return extractProperty(obj, prop)
+    }
+  }
+}
+
+// -------------------------------------------------------------------
+
 // Format a date in ISO 8601 in a safe way to be used in filenames
 // (even on Windows).
 export const safeDateFormat = d3TimeFormat('%Y%m%dT%H%M%SZ')

--- a/src/xapi-object-to-xo.js
+++ b/src/xapi-object-to-xo.js
@@ -1,4 +1,3 @@
-import includes from 'lodash.includes'
 import isArray from 'lodash.isarray'
 
 import {
@@ -307,8 +306,6 @@ const TRANSFORMS = {
         })(),
         install_repository: otherConfig['install-repository']
       }
-    } else if (includes(obj.current_operations, 'migrate_send')) {
-      vm.id = obj.$ref
     }
 
     if (!isHvm) {


### PR DESCRIPTION
When there is a conflict, the existing object keep the place but when it is removed, the other object (which is in the waiting list) will take the new place.