### PR TITLE
Correct the redis protocol in sample config

### DIFF
--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -117,9 +117,9 @@ http:
 
 # Connection to the Redis server.
 redis:
-    # Syntax: tcp://[db[:password]@]hostname[:port]
+    # Syntax: redis://[db[:password]@]hostname[:port]
     #
-    # Default: tcp://localhost:6379
+    # Default: redis://localhost:6379
     #uri: ''
 
 # Directory containing the database of XO.


### PR DESCRIPTION
The existing sample configuration file documents the Redis uri string with 'tcp://' prefix string, while xo-server actually expects it to be 'redis://' instead.