### PR TITLE
`GenericXoError` to throw errors with human readable message.

### DIFF
--- a/src/api-errors.js
+++ b/src/api-errors.js
@@ -58,3 +58,11 @@ export class ForbiddenOperation extends JsonRpcError {
     super(`forbidden operation: ${operation}`, 5, reason)
   }
 }
+
+// -------------------------------------------------------------------
+
+export class GenericXoError extends JsonRpcError {
+  constructor (message) {
+    super(message, 6)
+  }
+}

--- a/src/api-errors.js
+++ b/src/api-errors.js
@@ -61,7 +61,9 @@ export class ForbiddenOperation extends JsonRpcError {
 
 // -------------------------------------------------------------------
 
-export class GenericXoError extends JsonRpcError {
+// To be used with a user-readable message.
+// The message can be destined to be displayed to the front-end user.
+export class GenericError extends JsonRpcError {
   constructor (message) {
     super(message, 6)
   }

--- a/src/api/pbd.js
+++ b/src/api/pbd.js
@@ -30,7 +30,7 @@ export async function disconnect ({PBD}) {
     await this.getXapi(PBD).call('PBD.unplug', PBD._xapiRef)
   } catch (error) {
     if (error.code === 'VDI_IN_USE') {
-      throw new GenericError('vdi in use')
+      throw new GenericError('VDI in use')
     } else {
       throw error
     }

--- a/src/api/pbd.js
+++ b/src/api/pbd.js
@@ -1,3 +1,7 @@
+import {
+  GenericXoError
+} from '../api-errors'
+
 // FIXME: too low level, should be removed.
 
 // ===================================================================
@@ -22,7 +26,15 @@ delete_.resolve = {
 
 export async function disconnect ({PBD}) {
   // TODO: check if PBD is attached before
-  await this.getXapi(PBD).call('PBD.unplug', PBD._xapiRef)
+  try {
+    await this.getXapi(PBD).call('PBD.unplug', PBD._xapiRef)
+  } catch (error) {
+    if (error.code === 'VDI_IN_USE') {
+      throw new GenericXoError('VDI in use.')
+    } else {
+      throw error
+    }
+  }
 }
 
 disconnect.params = {

--- a/src/api/pbd.js
+++ b/src/api/pbd.js
@@ -1,5 +1,5 @@
 import {
-  GenericXoError
+  GenericError
 } from '../api-errors'
 
 // FIXME: too low level, should be removed.
@@ -30,7 +30,7 @@ export async function disconnect ({PBD}) {
     await this.getXapi(PBD).call('PBD.unplug', PBD._xapiRef)
   } catch (error) {
     if (error.code === 'VDI_IN_USE') {
-      throw new GenericXoError('VDI in use.')
+      throw new GenericError('vdi in use')
     } else {
       throw error
     }

--- a/src/api/pool.js
+++ b/src/api/pool.js
@@ -1,4 +1,4 @@
-import {JsonRpcError} from '../api-errors'
+import {GenericError} from '../api-errors'
 
 // ===================================================================
 
@@ -110,7 +110,7 @@ export async function mergeInto ({ source, target, force }) {
     await this.mergeXenPools(source._xapiId, target._xapiId, force)
   } catch (e) {
     // FIXME: should we expose plain XAPI error messages?
-    throw new JsonRpcError(e.message)
+    throw new GenericError(e.message)
   }
 }
 

--- a/src/api/vm.coffee
+++ b/src/api/vm.coffee
@@ -1006,7 +1006,7 @@ handleVmImport = $coroutine (req, res, { xapi, srId }) ->
     res.end(format.response(0, vm.$id))
   catch e
     res.writeHead(500)
-    res.end(format.error(new GenericError(e.message)))
+    res.end(format.error(0, new GenericError(e.message)))
 
   return
 

--- a/src/api/vm.coffee
+++ b/src/api/vm.coffee
@@ -13,7 +13,7 @@ startsWith = require 'lodash.startswith'
 {format} = require 'json-rpc-peer'
 
 {
-  JsonRpcError,
+  GenericError,
   Unauthorized
 } = require('../api-errors')
 {
@@ -818,7 +818,7 @@ exports.rollingBackup = rollingBackup
 
 rollingDrCopy = ({vm, pool, tag, depth}) ->
   if vm.$pool is pool.id
-    throw new JsonRpcError('Disaster Recovery attempts to copy on the same pool')
+    throw new GenericError('Disaster Recovery attempts to copy on the same pool')
   return @rollingDrCopyVm({vm, sr: @getObject(pool.default_SR, 'SR'), tag, depth})
 
 rollingDrCopy.params = {
@@ -1006,7 +1006,7 @@ handleVmImport = $coroutine (req, res, { xapi, srId }) ->
     res.end(format.response(0, vm.$id))
   catch e
     res.writeHead(500)
-    res.end(format.error(new JsonRpcError(e.message)))
+    res.end(format.error(new GenericError(e.message)))
 
   return
 

--- a/src/xapi.js
+++ b/src/xapi.js
@@ -45,7 +45,7 @@ import {
   pSettle
 } from './utils'
 import {
-  JsonRpcError,
+  GenericError,
   ForbiddenOperation
 } from './api-errors'
 
@@ -465,7 +465,7 @@ export default class Xapi extends XapiBase {
     )
 
     if (statusCode !== 200) {
-      throw new JsonRpcError('cannot fetch patches list from Citrix')
+      throw new GenericError('cannot fetch patches list from Citrix')
     }
 
     const data = parseXml(await readAll()).patchdata

--- a/src/xo-mixins/jobs.js
+++ b/src/xo-mixins/jobs.js
@@ -1,7 +1,7 @@
 import JobExecutor from '../job-executor'
 import { Jobs } from '../models/job'
 import {
-  JsonRpcError,
+  GenericError,
   NoSuchObject
 } from '../api-errors'
 
@@ -70,7 +70,7 @@ export default class {
       }
     }
     if (notFound.length > 0) {
-      throw new JsonRpcError(`The following jobs were not found: ${notFound.join()}`)
+      throw new GenericError(`The following jobs were not found: ${notFound.join()}`)
     }
   }
 }

--- a/src/xo-mixins/xen-servers.js
+++ b/src/xo-mixins/xen-servers.js
@@ -2,7 +2,7 @@ import Xapi from '../xapi'
 import xapiObjectToXo from '../xapi-object-to-xo'
 import XapiStats from '../xapi-stats'
 import {
-  JsonRpcError,
+  GenericError,
   NoSuchObject
 } from '../api-errors'
 import {
@@ -287,10 +287,10 @@ export default class {
       await xapi.connect()
     } catch (error) {
       if (error.code === 'SESSION_AUTHENTICATION_FAILED') {
-        throw new JsonRpcError('authentication failed')
+        throw new GenericError('authentication failed')
       }
       if (error.code === 'EHOSTUNREACH') {
-        throw new JsonRpcError('host unreachable')
+        throw new GenericError('host unreachable')
       }
       throw error
     }


### PR DESCRIPTION
- `GenericXoError` throws a `JsconRcpError` with code 6 and a user readable message.
- `pbd.unplug` throws a `GenericXoError` when `VDI_IN_USE` error is caught (See vatesfr/xo-web#810)