### PR TITLE
Fix pool autopoweron value from on to true

### DIFF
--- a/src/xapi.js
+++ b/src/xapi.js
@@ -428,7 +428,7 @@ export default class Xapi extends XapiBase {
         nameDescription
       }),
       autoPoweron != null && this._updateObjectMapProperty(pool, 'other_config', {
-        autoPoweron: autoPoweron ? 'on' : null
+        autoPoweron: autoPoweron ? 'true' : null
       })
     ])
   }


### PR DESCRIPTION
when enabling auto power on for the pool, the other_config value should
be "true", not "on" - http://support.citrix.com/article/CTX133910

as discussed here - https://github.com/vatesfr/xo-server/issues/309