### PR TITLE
Revert "fix(Xapi#snapshotVm): fallback if quiesce failed"

### DIFF
--- a/src/xapi/index.js
+++ b/src/xapi/index.js
@@ -1309,16 +1309,9 @@ export default class Xapi extends XapiBase {
 
       await this._waitObjectState(ref, vm => includes(vm.tags, 'quiesce'))
     } catch (error) {
-      const { code } = error
       if (
-        code !== 'VM_SNAPSHOT_WITH_QUIESCE_NOT_SUPPORTED' &&
-
-        // quiesce only work on a running VM
-        code !== 'VM_BAD_POWER_STATE' &&
-
-        // quiesce failed, fallback on standard snapshot
-        // TODO: emit warning
-        code !== 'VM_SNAPSHOT_WITH_QUIESCE_FAILED'
+        error.code !== 'VM_SNAPSHOT_WITH_QUIESCE_NOT_SUPPORTED' &&
+        error.code !== 'VM_BAD_POWER_STATE' // quiesce only work on a running VM
       ) {
         throw error
       }


### PR DESCRIPTION
This reverts commit 3263511b7236f7989b0b89762c833162ab3882c8.

It leads to more harm than good: if VM has quiesce support,
snapshotting should fail on error.